### PR TITLE
Handle dashed attributes (Fixes #6)

### DIFF
--- a/lib/process-node-definitions.js
+++ b/lib/process-node-definitions.js
@@ -1,12 +1,5 @@
 'use strict';
-var isEmpty = require('lodash.isempty');
-var map = require('lodash.map');
-var fromPairs = require('lodash.frompairs');
-var camelCase = require('lodash.camelcase');
-var includes = require('lodash.includes');
-var merge = require('lodash.merge');
 var ent = require('ent');
-var camelCaseAttrMap = require('./camel-case-attribute-names');
 var utils = require('./utils');
 
 // https://github.com/facebook/react/blob/15.0-stable/src/renderers/dom/shared/ReactDOMComponent.js#L457
@@ -14,23 +7,6 @@ var voidElementTags = [
     'area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input', 'keygen', 'link', 'meta', 'param',
     'source', 'track', 'wbr', 'menuitem', 'textarea',
 ];
-
-function createStyleJsonFromString(styleString) {
-    if (!styleString) {
-        return {};
-    }
-    var styles = styleString.split(';');
-    var singleStyle, key, value, jsonStyles = {};
-    for (var i = 0; i < styles.length; i++) {
-        singleStyle = styles[i].split(':');
-        key = camelCase(singleStyle[0]);
-        value = singleStyle[1];
-        if (key.length > 0 && value.length > 0) {
-            jsonStyles[key] = value;
-        }
-    }
-    return jsonStyles;
-}
 
 var ProcessNodeDefinitions = function() {
     function processDefaultNode(node, children, index) {
@@ -44,22 +20,7 @@ var ProcessNodeDefinitions = function() {
         }
 
         var elementProps = utils.createElementProps(node, index);
-        // Process attributes
-        if (!isEmpty(node.attribs)) {
-            elementProps = merge(elementProps, fromPairs(map(node.attribs, function (value, key) {
-                if (key === 'style') {
-                    value = createStyleJsonFromString(node.attribs.style);
-                } else if (key === 'class') {
-                    key = 'className';
-                } else if (camelCaseAttrMap[key]) {
-                    key = camelCaseAttrMap[key];
-                }
-
-                return [key, value || key,];
-            })));
-        }
-
-        if (includes(voidElementTags, node.name)) {
+        if (voidElementTags.indexOf(node.name) > -1) {
             return utils.createElement(node.name, elementProps);
         } else {
             return utils.createElement(node.name, elementProps, node.data, children);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,6 +4,11 @@ var reduce = require('lodash.reduce');
 var React = require('react');
 var camelCaseAttrMap = require('./camel-case-attribute-names');
 
+function getCamelCaseAttr(key) {
+    key = key.replace(/-/, '');
+    return camelCaseAttrMap[key];
+}
+
 function createStyleJsonFromString(styleString) {
     if (!styleString) {
         return {};
@@ -27,7 +32,7 @@ function createElementProps(node, index) {
     };
     if (node.attribs) {
         elementProps = reduce(node.attribs, function(result, value, key) {
-            key = camelCaseAttrMap[key] || key;
+            key = getCamelCaseAttr(key) || key;
             if (key === 'style') {
                 value = createStyleJsonFromString(node.attribs.style);
             } else if (key === 'class') {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,8 +1,8 @@
 'use strict';
 var camelCase = require('lodash.camelcase');
-var forEach = require('lodash.foreach');
-var includes = require('lodash.includes');
+var reduce = require('lodash.reduce');
 var React = require('react');
+var camelCaseAttrMap = require('./camel-case-attribute-names');
 
 function createStyleJsonFromString(styleString) {
     if (!styleString) {
@@ -26,19 +26,16 @@ function createElementProps(node, index) {
         key: index,
     };
     if (node.attribs) {
-        forEach(node.attribs, function (value, key) {
-            switch (key || '') {
-                case 'style':
-                    elementProps.style = createStyleJsonFromString(node.attribs.style);
-                    break;
-                case 'class':
-                    elementProps.className = value;
-                    break;
-                default:
-                    elementProps[key] = value;
-                    break;
+        elementProps = reduce(node.attribs, function(result, value, key) {
+            key = camelCaseAttrMap[key] || key;
+            if (key === 'style') {
+                value = createStyleJsonFromString(node.attribs.style);
+            } else if (key === 'class') {
+                key = 'className';
             }
-        });
+            result[key] = value || key;
+            return result;
+        }, elementProps);
     }
 
     return elementProps;

--- a/package.json
+++ b/package.json
@@ -39,12 +39,8 @@
     "htmlparser2": "^3.8.3",
     "lodash.camelcase": "^4.3.0",
     "lodash.find": "^4.6.0",
-    "lodash.foreach": "^4.5.0",
-    "lodash.frompairs": "^4.0.1",
-    "lodash.includes": "^4.3.0",
-    "lodash.isempty": "^4.4.0",
     "lodash.map": "^4.6.0",
-    "lodash.merge": "^4.6.0"
+    "lodash.reduce": "^4.6.0"
   },
   "peerDependencies": {
     "react": "^15.0"

--- a/test/html-to-react-tests.js
+++ b/test/html-to-react-tests.js
@@ -85,6 +85,14 @@ describe('Html2React', function () {
             assert.equal(reactHtml, htmlInput);
         });
 
+        it('should handle dashed attributes', function () {
+            var input = '<form accept-charset="en"><svg viewBox="0 0 10 10"><text text-anchor="left"></text><circle stroke="black" stroke-width="42"></circle></svg></form>';
+            var reactComponent = parser.parse(input);
+            var reactHtml = ReactDOMServer.renderToStaticMarkup(reactComponent);
+
+            assert.equal(reactHtml, input);
+        });
+
         // FIXME: See lib/process-node-definitions.js -> processDefaultNode()
         it.skip('should return a valid HTML string with comments', function () {
             var htmlInput = '<div><!-- This is a comment --></div>';


### PR DESCRIPTION
The prop merge code does not pick up attributes with `-` (e.g. `stroke-width`), additionally, it does not replace the camelCased keys causing react to complain about extra keys.

Summary of changes:
- Refactored prop generation (there was duplicate code)
- Removed unused lodash imports
- Added test case