### PR TITLE
handle xmlns attributes (e.g. xlink:href)

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -30,7 +30,7 @@ function createElement(node, index, data, children) {
     elementProps = reduce(function(result, keyAndValue) {
       var key = keyAndValue[0];
       var value = keyAndValue[1];
-      key = camelCaseAttrMap[key.replace(/-/, '')] || key;
+      key = camelCaseAttrMap[key.replace(/[-:]/, '')] || key;
       if (key === 'style') {
         value = createStyleJsonFromString(value);
       } else if (key === 'class') {

--- a/test/html-to-react-tests.js
+++ b/test/html-to-react-tests.js
@@ -390,4 +390,14 @@ describe('Html2React', function () {
       });
     });
   });
+
+  describe('parse SVG', function () {
+    it('should have correct attributes', function () {
+      var svgInput = '<svg><image xlink:href="http://i.imgur.com/w7GCRPb.png" /></svg>';
+      var reactComponent = parser.parse(svgInput);
+      var reactHtml = ReactDOMServer.renderToStaticMarkup(reactComponent);
+
+      assert(/<image xlink:href="http:\/\/i.imgur.com\/w7GCRPb.png"/.test(reactHtml), reactHtml + ' has expected attributes');
+    });
+  });
 });


### PR DESCRIPTION
The current version can't handle `xlink:href` whereas `camel-case-attribute-names.js` has `xlinkHref` and so on.

This PR fix the issue, including unit tests.