### PR TITLE
parsing multiple root elements

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -44,14 +44,7 @@ function Html2ReactParser(options) {
 
   function parseWithInstructions(html, isValidNode, processingInstructions) {
     var domTree = parseHtmlToTree(html);
-    // TODO: Deal with HTML that contains more than one root level node
-    /*if (domTree && domTree.length !== 1) {
-      throw new Error(
-        'html-to-react currently only supports HTML with one single root element. ' +
-        'The HTML provided contains ' + domTree.length +
-        ' root elements. You can fix that by simply wrapping your HTML ' +
-        'in a <div> element.');
-    }*/
+
     var list = domTree.map(function (domTreeItem, index) {
       return traverseDom(domTreeItem, isValidNode, processingInstructions, index);
     });

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -45,14 +45,20 @@ function Html2ReactParser(options) {
   function parseWithInstructions(html, isValidNode, processingInstructions) {
     var domTree = parseHtmlToTree(html);
     // TODO: Deal with HTML that contains more than one root level node
-    if (domTree && domTree.length !== 1) {
+    /*if (domTree && domTree.length !== 1) {
       throw new Error(
         'html-to-react currently only supports HTML with one single root element. ' +
         'The HTML provided contains ' + domTree.length +
         ' root elements. You can fix that by simply wrapping your HTML ' +
         'in a <div> element.');
+    }*/
+    var list = domTree.map(function (domTreeItem, index) {
+      return traverseDom(domTreeItem, isValidNode, processingInstructions, index);
+    });
+    if (list.length === 1) {
+      return list[0];
     }
-    return traverseDom(domTree[0], isValidNode, processingInstructions, 0);
+    return list;
   };
 
   function parse(html) {

--- a/test/html-to-react-tests.js
+++ b/test/html-to-react-tests.js
@@ -395,13 +395,22 @@ describe('Html2React', function () {
   });
 
   describe('parse multiple elements', function() {
-    it('should throw an error when trying parsing multiple root elements', function () {
+    it('should parse multiple root elements', function () {
       var htmlInput = '<div></div><div></div>';
       var components = parser.parse(htmlInput);
       var output = components.map(function (component) {
         return ReactDOMServer.renderToStaticMarkup(component);
       }).join('');
       assert.equal(htmlInput, output);
+    });
+
+    it('should be able to parse and render multiple children elements', function() {
+      var htmlInput = '<li>first</li><li>second</li><li>third</li>';
+      var components = parser.parse(htmlInput);
+      var output = ReactDOMServer.renderToStaticMarkup(
+        React.createElement('ul', null, components)
+      );
+      assert.equal('<ul>' + htmlInput + '</ul>', output);
     });
   });
 });

--- a/test/html-to-react-tests.js
+++ b/test/html-to-react-tests.js
@@ -212,7 +212,7 @@ describe('Html2React', function () {
 
     it('should decode attribute values to avoid React re-encoding them', function () {
       var htmlInput = '<p><a href="http://domain.com/search?query=1&amp;lang=en">A link</a></p>';
-      
+
       var reactComponent = parser.parse(htmlInput);
       var reactHtml = ReactDOMServer.renderToStaticMarkup(reactComponent);
 
@@ -221,23 +221,6 @@ describe('Html2React', function () {
   });
 
   describe('parse invalid HTML', function () {
-    it('should throw an error when trying parsing multiple root elements', function () {
-      var htmlInput = '<div></div><div></div>';
-
-      assert.throws(function () {
-        parser.parse(htmlInput);
-      }, Error);
-    });
-
-    it('should throw an error with a specific message when parsing multiple root elements',
-    function () {
-      var htmlInput = '<div></div><div></div><div></div>';
-
-      assert.throws(function () {
-        parser.parse(htmlInput);
-      }, /contains 3 root elements/);
-    });
-
     it('should fix missing closing tags', function () {
       var htmlInput = '<div><p></div>';
       var htmlExpected = '<div><p></p></div>';
@@ -408,6 +391,17 @@ describe('Html2React', function () {
 
       assert(/<image xlink:href="http:\/\/i.imgur.com\/w7GCRPb.png"/.test(reactHtml), reactHtml +
         ' has expected attributes');
+    });
+  });
+
+  describe('parse multiple elements', function() {
+    it('should throw an error when trying parsing multiple root elements', function () {
+      var htmlInput = '<div></div><div></div>';
+      var components = parser.parse(htmlInput);
+      var output = components.map(function (component) {
+        return ReactDOMServer.renderToStaticMarkup(component);
+      }).join('');
+      assert.equal(htmlInput, output);
     });
   });
 });


### PR DESCRIPTION
I know that `ReactDOM.renderToStaticMarkup()` does not accept multipe elements but when you need to parse the children elements that you want to be rendered inside a react component, the ability to parse them can be handy (see test in commit f015841)