### PR TITLE
Added test for inline style ie11 issue.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -14,18 +14,15 @@ function createStyleJsonFromString(styleString) {
     if (singleStyle.length > 2) {
       singleStyle[1] = singleStyle.slice(1).join(':');
     }
-
     key = camelize(singleStyle[0]);
     value = singleStyle[1];
     if (typeof value === 'string'){
       value = value.trim();
     }
-
     if (key.length > 0 && value.length > 0) {
       jsonStyles[key] = value;
     }
   }
-
   return jsonStyles;
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -14,13 +14,18 @@ function createStyleJsonFromString(styleString) {
     if (singleStyle.length > 2) {
       singleStyle[1] = singleStyle.slice(1).join(':');
     }
-    
+
     key = camelize(singleStyle[0]);
     value = singleStyle[1];
+    if (typeof value === 'string'){
+      value = value.trim();
+    }
+
     if (key.length > 0 && value.length > 0) {
       jsonStyles[key] = value;
     }
   }
+
   return jsonStyles;
 }
 

--- a/test/html-to-react-tests.js
+++ b/test/html-to-react-tests.js
@@ -403,6 +403,14 @@ describe('Html2React', function () {
 
         assert.equal(reactComponent.props.children.length, 5);
       });
+
+      it('Inline style should not contain usless spaces', function () {
+        var htmlInput = '<p style="text-align: center"></p>';
+
+        var reactComponent = parser.parse(htmlInput);
+
+        assert.equal(reactComponent.props.style.textAlign, 'center');
+      });
     });
   });
 

--- a/test/html-to-react-tests.js
+++ b/test/html-to-react-tests.js
@@ -241,6 +241,14 @@ describe('Html2React', function () {
 
       assert.equal(reactHtml, htmlInput);
     });
+
+    it('should handle spaces in inline styles', function () {
+      var htmlInput = '<p style="text-align: center"></p>';
+
+      var reactComponent = parser.parse(htmlInput);
+
+      assert.equal(reactComponent.props.style.textAlign, 'center');
+    });
   });
 
   describe('parse invalid HTML', function () {
@@ -402,14 +410,6 @@ describe('Html2React', function () {
         var reactComponent = parser.parse(htmlInput);
 
         assert.equal(reactComponent.props.children.length, 5);
-      });
-
-      it('Inline style should not contain usless spaces', function () {
-        var htmlInput = '<p style="text-align: center"></p>';
-
-        var reactComponent = parser.parse(htmlInput);
-
-        assert.equal(reactComponent.props.style.textAlign, 'center');
       });
     });
   });

--- a/test/html-to-react-tests.js
+++ b/test/html-to-react-tests.js
@@ -31,9 +31,9 @@ describe('Html2React', function () {
     });
 
     it('should return a valid HTML string with inline styles', function () {
-      var htmlInput = '<div style="background-image: url(' +
-        '&quot;http://lorempixel.com/400/200/&quot;);background-color: red;color: white;' +
-        'font-family: &quot;Open Sans&quot;;"></div>';
+      var htmlInput = '<div style="background-image:url(' +
+        '&quot;http://lorempixel.com/400/200/&quot;);background-color:red;color:white;' +
+        'font-family:&quot;Open Sans&quot;;"></div>';
 
       var reactComponent = parser.parse(htmlInput);
       var reactHtml = ReactDOMServer.renderToStaticMarkup(reactComponent);
@@ -42,9 +42,9 @@ describe('Html2React', function () {
     });
 
     it('should return a valid HTML string with inline image in style', function () {
-      var htmlInput = '<div style="background: url(' +
-        'data:image/png;base64,iVBORw0KGgoAAA);color: white;' +
-        'font-family: &quot;Open Sans&quot;;"></div>';
+      var htmlInput = '<div style="background:url(' +
+        'data:image/png;base64,iVBORw0KGgoAAA);color:white;' +
+        'font-family:&quot;Open Sans&quot;;"></div>';
 
       var reactComponent = parser.parse(htmlInput);
       var reactHtml = ReactDOMServer.renderToStaticMarkup(reactComponent);


### PR DESCRIPTION
The issue appears only on IE11 and older. When calling createStyleJsonFromString, sometimes you get style value that starts with " ". IE don't like it and strips it.