### PR TITLE
Remove dependency vulnerability

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,5 @@
 'use strict';
-var camelize = require('underscore.string.fp/camelize');
+var camelCase = require('lodash.camelcase');
 var toPairs = require('ramda/src/toPairs');
 var reduce = require('ramda/src/reduce');
 var React = require('react');
@@ -22,7 +22,7 @@ function createStyleJsonFromString(styleString) {
     }
 
     if (key != null && value != null && key.length > 0 && value.length > 0) {
-      jsonStyles[camelize(key)] = value;
+      jsonStyles[camelCase(key)] = value;
     }
   }
   return jsonStyles;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "html-to-react",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -101,11 +101,6 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "arity-n": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/arity-n/-/arity-n-1.0.4.tgz",
-      "integrity": "sha1-2edrEXM+CFacCEeuezmyhgswt0U="
-    },
     "array-union": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
@@ -247,11 +242,6 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
-    "chickencurry": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/chickencurry/-/chickencurry-1.1.1.tgz",
-      "integrity": "sha1-AmVfKyazvC7hrh5TFoht4463lzg="
-    },
     "circular-json": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
@@ -323,14 +313,6 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
       "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
       "dev": true
-    },
-    "compose-function": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/compose-function/-/compose-function-2.0.0.tgz",
-      "integrity": "sha1-5kL6fh2iFSlyADFHZ3b8JGkawLA=",
-      "requires": {
-        "arity-n": "^1.0.4"
-      }
     },
     "concat-map": {
       "version": "0.0.1",
@@ -1191,6 +1173,11 @@
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
       "dev": true
     },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+    },
     "log-driver": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
@@ -1616,11 +1603,6 @@
         "signal-exit": "^3.0.2"
       }
     },
-    "reverse-arguments": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/reverse-arguments/-/reverse-arguments-1.0.0.tgz",
-      "integrity": "sha1-woCVo6khrHFdYYNN3s6QJ5kmZ80="
-    },
     "right-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
@@ -1898,22 +1880,6 @@
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
       "dev": true,
       "optional": true
-    },
-    "underscore.string": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.0.3.tgz",
-      "integrity": "sha1-Rhe4waJQz25QZPu7Nj0PqWzxRVI="
-    },
-    "underscore.string.fp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/underscore.string.fp/-/underscore.string.fp-1.0.4.tgz",
-      "integrity": "sha1-BUs/GEO8rlYShsh95eiHm0/Jg2Q=",
-      "requires": {
-        "chickencurry": "1.1.1",
-        "compose-function": "^2.0.0",
-        "reverse-arguments": "1.0.0",
-        "underscore.string": "3.0.3"
-      }
     },
     "uri-js": {
       "version": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
     "domhandler": "^2.4.2",
     "escape-string-regexp": "^1.0.5",
     "htmlparser2": "^3.10.0",
-    "ramda": "^0.26",
-    "underscore.string.fp": "^1.0.4"
+    "lodash.camelcase": "^4.3.0",
+    "ramda": "^0.26"
   },
   "peerDependencies": {
     "react": "^16.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "html-to-react",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "A lightweight library that converts raw HTML to a React DOM structure.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
`underscore.string` package has a Regular Expression Denial of Service (ReDoS) vulnerability. See more information here: https://app.snyk.io/vuln/npm:underscore.string:20170908

It is a dependency of `underscore.string.fp`, which has not been updated in years. The only method used from that package in `html-to-react` is `camelize`. There are countless other camelize versions available - i chose to install one that fits the spirit of underscore: `lodash.camelcase`.

Tests passed on my system. I also updated the patch version to v`1.3.4` so that this pull request can directly be published to npm after merge.

Please merge and npm publish so i can pull request some upstream repositories that depend on this one! 🔥 