### PR TITLE
add test case for brackets inside valid html elements

### DIFF
--- a/test/html-to-react-tests.js
+++ b/test/html-to-react-tests.js
@@ -283,6 +283,17 @@ describe('Html2React', function () {
 
       assert.strictEqual(reactElem.props.value, '');
     });
+    
+    it('should parse valid HTML string that contains "<" character inside its content',
+      function () {
+        const htmlInput = '<code> <- </code>';
+        const htmlExpected = '<code> <- </code>';
+
+        const reactComponent = parser.parse(htmlInput);
+        const reactHtml = ReactDOMServer.renderToStaticMarkup(reactComponent);
+
+        assert.equal(reactHtml, htmlExpected);
+    });
   });
 
   describe('parse invalid HTML', function () {


### PR DESCRIPTION
This is a test case for issue #115 

The test fails with: 
```
     Error: Invalid tag: -
      at validateDangerousTag (node_modules/react-dom/cjs/react-dom-server.node.development.js:2748:15)
      at ReactDOMServerRenderer.renderDOM (node_modules/react-dom/cjs/react-dom-server.node.development.js:3767:5)
      at ReactDOMServerRenderer.render (node_modules/react-dom/cjs/react-dom-server.node.development.js:3484:21)
      at ReactDOMServerRenderer.read (node_modules/react-dom/cjs/react-dom-server.node.development.js:3373:29)
      at Object.renderToStaticMarkup (node_modules/react-dom/cjs/react-dom-server.node.development.js:4004:27)
      at Context.<anonymous> (test/html-to-react-tests.js:293:42)
      at processImmediate (internal/timers.js:439:21)
```