### PR TITLE
Fix handling of boolean HTML attributes which differ from React's representation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Change Log
+
+## Master/Unreleased
+- Handle boolean attributes differing from React's representation [\#132](https://github.com/aknuds1/html-to-react/pull/132) ([aknuds1](https://github.com/aknuds1))
+
 ## [v1.4.3](https://github.com/aknuds1/html-to-react/tree/v1.4.3)
 
 - Handle non-boolean empty element attributes

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -29,29 +29,30 @@ function createStyleJsonFromString(styleString) {
   return jsonStyles;
 }
 
-// Boolean HTML attributes, copied from https://meiert.com/en/blog/boolean-attributes-of-html/
+// Boolean HTML attributes, copied from https://meiert.com/en/blog/boolean-attributes-of-html/,
+// on the form React expects.
 const booleanAttrs = [
-  'allowfullscreen',
+  'allowFullScreen',
   'allowpaymentrequest',
   'async',
-  'autofocus',
-  'autoplay',
+  'autoFocus',
+  'autoPlay',
   'checked',
   'controls',
   'default',
   'disabled',
-  'formnovalidate',
+  'formNoValidate',
   'hidden',
   'ismap',
-  'itemscope',
+  'itemScope',
   'loop',
   'multiple',
   'muted',
   'nomodule',
-  'novalidate',
+  'noValidate',
   'open',
   'playsinline',
-  'readonly',
+  'readOnly',
   'required',
   'reversed',
   'selected',
@@ -64,7 +65,6 @@ function createElement(node, index, data, children) {
   };
   if (node.attribs) {
     elementProps = reduce(function(result, keyAndValue) {
-      console.log(`Handling keyAndValue ${keyAndValue}`);
       let key = keyAndValue[0];
       let value = keyAndValue[1];
       key = camelCaseAttrMap[key.replace(/[-:]/, '')] || key;
@@ -93,5 +93,5 @@ function createElement(node, index, data, children) {
 }
 
 module.exports = {
-  createElement: createElement,
+  createElement,
 };

--- a/test/boolattrs.js
+++ b/test/boolattrs.js
@@ -1,0 +1,32 @@
+'use strict';
+
+// Boolean HTML attributes, in the case React expects.
+const booleanAttrs = [
+  'allowFullScreen',
+  'allowpaymentrequest',
+  'async',
+  'autoFocus',
+  'autoPlay',
+  'checked',
+  'controls',
+  'default',
+  'disabled',
+  'formNoValidate',
+  'hidden',
+  'ismap',
+  'itemScope',
+  'loop',
+  'multiple',
+  'muted',
+  'nomodule',
+  'noValidate',
+  'open',
+  'playsinline',
+  'readOnly',
+  'required',
+  'reversed',
+  'selected',
+  'truespeed',
+];
+
+module.exports = booleanAttrs;

--- a/test/html-to-react-tests.js
+++ b/test/html-to-react-tests.js
@@ -6,6 +6,7 @@ const R = require('ramda');
 
 const Parser = require('..').Parser;
 const ProcessNodeDefinitions = require('..').ProcessNodeDefinitions;
+const booleanAttrs = require('./boolattrs');
 
 describe('Html2React', () => {
   const parser = new Parser();
@@ -283,6 +284,16 @@ describe('Html2React', () => {
 
       assert.strictEqual(reactElem.props.value, '');
     });
+
+    it('should handle boolean attributes with implicit value', function () {
+      R.forEach((attr) => {
+        const htmlInput = `<input ${attr.toLowerCase()}>`;
+
+        const reactElem = parser.parse(htmlInput);
+
+        assert.strictEqual(reactElem.props[attr], attr);
+      }, booleanAttrs);
+    });
   });
 
   describe('parse invalid HTML', () => {
@@ -539,7 +550,7 @@ describe('Html2React', () => {
           // eslint-disable-next-line max-len
           /<svg xmlns="http:\/\/www\.w3\.org\/2000\/svg" xmlns:xlink="http:\/\/www\.w3\.org\/1999\/xlink"><\/svg>/,
       };
-      R.forEach(function (inputAndRegExp) {
+      R.forEach((inputAndRegExp) => {
         const input = inputAndRegExp[0], regExp = inputAndRegExp[1];
         const reactComponent = parser.parse(input);
         const reactHtml = ReactDOMServer.renderToStaticMarkup(reactComponent);


### PR DESCRIPTION
Some boolean HTML attributes, f.ex. `readonly`, are not processed correctly since they differ from React's representation (f.ex. `readonly` is represented by React as `readOnly`). This PR fixes those and adds a test for all boolean attributes.

Fixes #129.