### PR TITLE
chore(package.json): ramda@0.28.0 bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "domhandler": "^4.0",
         "htmlparser2": "^7.0",
         "lodash.camelcase": "^4.3.0",
-        "ramda": "^0.27.1"
+        "ramda": "^0.28.0"
       },
       "devDependencies": {
         "coveralls": "^3.1.0",
@@ -2990,9 +2990,13 @@
       }
     },
     "node_modules/ramda": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.2.tgz",
-      "integrity": "sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA=="
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
+      "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ramda"
+      }
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
@@ -5882,9 +5886,9 @@
       "dev": true
     },
     "ramda": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.2.tgz",
-      "integrity": "sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA=="
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
+      "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA=="
     },
     "randombytes": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "domhandler": "^4.0",
     "htmlparser2": "^7.0",
     "lodash.camelcase": "^4.3.0",
-    "ramda": "^0.27.1"
+    "ramda": "^0.28.0"
   },
   "peerDependencies": {
     "react": "^16.0 || ^17.0"


### PR DESCRIPTION
ramda@0.27.1 has security vulnerability issues, you can check the release note [here](https://github.com/ramda/ramda/releases/tag/v0.27.2). hence, this PR to bump it to the latest version. I used the same node 16.13.2 version which was mentioned in the package.json to comply with the lock file generator.