### PR TITLE
Don't camelCase CSS custom properties

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -20,7 +20,14 @@ function createStyleJsonFromString(styleString) {
     }
 
     if (key != null && value != null && key.length > 0 && value.length > 0) {
-      jsonStyles[camelCase(key)] = value;
+      key = key.trim();
+
+      // Don't camelCase CSS custom properties
+      if (key.indexOf('--') !== 0) {
+        key = camelCase(key);
+      }
+
+      jsonStyles[key] = value;
     }
   }
   return jsonStyles;

--- a/test/html-to-react-tests.js
+++ b/test/html-to-react-tests.js
@@ -61,6 +61,15 @@ describe('Html2React', () => {
       assert.equal(reactHtml, htmlExpected);
     });
 
+    it('should return a valid HTML string with custom properties in inline styles', () => {
+      const htmlInput = '<div style="color:var(--color-example);--color-example:black"></div>';
+
+      const reactComponent = parser.parse(htmlInput);
+      const reactHtml = ReactDOMServer.renderToStaticMarkup(reactComponent);
+
+      assert.equal(reactHtml, htmlInput);
+    });
+
     it('should return a valid HTML string with data attributes', () => {
       const htmlInput = '<div data-test-attribute="data attribute value"></div>';
 


### PR DESCRIPTION
The current camel case logic for inline style keys invalidates custom property rules in inline styles. This change checks to make sure the `key` doesn't start with `--` before processing it with `camelCase`.

See #144