### PR TITLE
Use React as a peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,7 @@
       "dependencies": {
         "domhandler": "^5.0",
         "htmlparser2": "^8.0",
-        "lodash.camelcase": "^4.3.0",
-        "react": "^18.0"
+        "lodash.camelcase": "^4.3.0"
       },
       "devDependencies": {
         "@types/mocha": "^10.0.1",
@@ -23,9 +22,13 @@
         "mocha": "^10.0",
         "mocha-lcov-reporter": "^1.2.0",
         "nyc": "^15.1.0",
+        "react": "^18.0",
         "react-dom": "^18.0",
         "ts-node": "^10.9.1",
         "typescript": "^5.0.3"
+      },
+      "peerDependencies": {
+        "react": "^0.13.0 || ^0.14.0 || >=15"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2335,7 +2338,8 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "node_modules/js-yaml": {
       "version": "3.14.1",
@@ -2502,6 +2506,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -3215,6 +3220,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },

--- a/package.json
+++ b/package.json
@@ -35,11 +35,13 @@
       ]
     }
   },
+  "peerDependencies": {
+    "react": "^0.13.0 || ^0.14.0 || >=15"
+  },
   "dependencies": {
     "domhandler": "^5.0",
     "htmlparser2": "^8.0",
-    "lodash.camelcase": "^4.3.0",
-    "react": "^18.0"
+    "lodash.camelcase": "^4.3.0"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.1",
@@ -50,6 +52,7 @@
     "mocha": "^10.0",
     "mocha-lcov-reporter": "^1.2.0",
     "nyc": "^15.1.0",
+    "react": "^18.0",
     "react-dom": "^18.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.3"


### PR DESCRIPTION
This PR sets up the package to use React as a peer dependency.

This is the [recommended way](https://stackoverflow.com/a/30454133) to add React to an external library and how many members of the React core team have it setup in [their packages](https://github.com/gaearon/react-side-effect/blob/master/package.json#L33).

This means that html-to-react will now leverage the version of React that the user has installed, instead of potentially using a different version within the module if the user is not on React v18.  This was causing an increased bundle size when installing `v1.5.1` when compared to `v1.5.0` which this should resolve.

-----

@aknuds1 Thanks again for maintaining this module as it has been extremely useful for handling HTML passed from a sever in a safe and customizable way.